### PR TITLE
maxRetries argument

### DIFF
--- a/cmd_worker.go
+++ b/cmd_worker.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/go-redis/redis"
 	"github.com/google/subcommands"
-	graphite "github.com/marpaia/graphite-golang"
+	"github.com/marpaia/graphite-golang"
 	_ "github.com/skx/golang-metrics"
 	"github.com/skx/overseer/parser"
 	"github.com/skx/overseer/protocols"
@@ -403,6 +403,10 @@ func (p *workerCmd) runTest(tst test.Test, opts test.Options) error {
 		//
 		if p.Retry == false {
 			maxAttempts = attempt + 1
+		}
+
+		if tst.MaxRetries >= 0 {
+			maxAttempts = tst.MaxRetries + 1
 		}
 
 		//

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -325,7 +325,7 @@ func (s *Parser) ParseLine(input string, cb ParsedTest) (test.Test, error) {
 	for arg, val := range result.Arguments {
 
 		// Is there a custom per-test override?
-		if arg == "maxRetries" {
+		if arg == "retries" {
 			maxRetries, err := strconv.ParseInt(val, 10, 32)
 			if err != nil {
 				return result, fmt.Errorf("Non-numeric argument '%s' for test-type '%s' in input '%s'", arg, testType, input)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/skx/overseer/protocols"
@@ -305,6 +306,7 @@ func (s *Parser) ParseLine(input string, cb ParsedTest) (test.Test, error) {
 	//
 	// Create a temporary structure to hold our test
 	//
+	result.MaxRetries = -1
 	result.Target = testTarget
 	result.Type = testType
 	result.Input = input
@@ -321,6 +323,19 @@ func (s *Parser) ParseLine(input string, cb ParsedTest) (test.Test, error) {
 	// For each argument which was supplied..
 	//
 	for arg, val := range result.Arguments {
+
+		// Is there a custom per-test override?
+		if arg == "maxRetries" {
+			maxRetries, err := strconv.ParseInt(val, 10, 32)
+			if err != nil {
+				return result, fmt.Errorf("Non-numeric argument '%s' for test-type '%s' in input '%s'", arg, testType, input)
+			}
+			result.MaxRetries = int(maxRetries)
+
+			// We don't want to pass a non-test var to the actual test
+			delete(result.Arguments, arg)
+			continue
+		}
 
 		//
 		// Is that argument present in the arguments the

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -507,6 +507,32 @@ func TestInvalidOptions(t *testing.T) {
 	}
 }
 
+func TestMaxRetries(t *testing.T) {
+	tests := []string{
+		"http://example.com/ must run http with maxRetries 0",
+		"http://example.com/ must run http with maxRetries 1",
+		"http://example.com/ must run http with maxRetries 2",
+	}
+
+	// Create a parser
+	p := New()
+
+	// Parse each line
+	for idx, input := range tests {
+
+		tst, err := p.ParseLine(input, nil)
+		if err != nil {
+			t.Errorf("We did not expect an error parsing %s!", input)
+			continue
+		}
+
+		if tst.MaxRetries != idx {
+			t.Errorf("Invalid maxRetries number. Expected %d, got %d", idx, tst.MaxRetries)
+
+		}
+	}
+}
+
 // Test invoking a callback.
 func TestCallback(t *testing.T) {
 	file, err := ioutil.TempFile(os.TempDir(), "prefix")

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -509,9 +509,9 @@ func TestInvalidOptions(t *testing.T) {
 
 func TestMaxRetries(t *testing.T) {
 	tests := []string{
-		"http://example.com/ must run http with maxRetries 0",
-		"http://example.com/ must run http with maxRetries 1",
-		"http://example.com/ must run http with maxRetries 2",
+		"http://example.com/ must run http with retries 0",
+		"http://example.com/ must run http with retries 1",
+		"http://example.com/ must run http with retries 2",
 	}
 
 	// Create a parser
@@ -527,7 +527,7 @@ func TestMaxRetries(t *testing.T) {
 		}
 
 		if tst.MaxRetries != idx {
-			t.Errorf("Invalid maxRetries number. Expected %d, got %d", idx, tst.MaxRetries)
+			t.Errorf("Invalid retries number. Expected %d, got %d", idx, tst.MaxRetries)
 
 		}
 	}

--- a/test/type.go
+++ b/test/type.go
@@ -40,6 +40,9 @@ type Test struct {
 	// In the example above this would be `1.2.3.4 must run ftp`.
 	Input string
 
+	// MaxRetries overrides the global overseer setting for max test retries, if >= 0
+	MaxRetries int
+
 	// Arguments contains a map of any optional arguments supplied to
 	// test test.
 	//


### PR DESCRIPTION
Add the `maxRetries` rule to rules:

```
# Runs only once
https://google.com must run http with status 301 with maxRetries 0

# Runs once + 2 retries
https://google.com must run http with status 301 with maxRetries 2
```

